### PR TITLE
Add multi nodes support for external zookeeper

### DIFF
--- a/lib/container/kafka_container.ex
+++ b/lib/container/kafka_container.ex
@@ -200,7 +200,10 @@ defmodule Testcontainers.KafkaContainer do
     defp with_topic_config(container, config) do
       container
       |> with_environment(:KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR, "1")
-      |> with_environment(:KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS, "#{config.default_topic_partitions}")
+      |> with_environment(
+        :KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS,
+        "#{config.default_topic_partitions}"
+      )
       |> with_environment(:KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR, "1")
       |> with_environment(:KAFKA_TRANSACTION_STATE_LOG_MIN_ISR, "1")
       |> with_environment(:KAFKA_AUTO_CREATE_TOPICS_ENABLE, "false")

--- a/test/container/kafka_container_test.exs
+++ b/test/container/kafka_container_test.exs
@@ -66,6 +66,20 @@ defmodule Testcontainers.Container.KafkaContainerTest do
     end
   end
 
+  describe "with_broker_id/2" do
+    test "overrides the default broker id used for the Kafka container" do
+      config = KafkaContainer.new()
+      new_config = KafkaContainer.with_broker_id(config, 2)
+
+      assert new_config.broker_id == 2
+    end
+
+    test "raises if the broker id is not integer" do
+      config = KafkaContainer.new()
+      assert_raise FunctionClauseError, fn -> KafkaContainer.with_broker_id(config, "2") end
+    end
+  end
+
   describe "with_zookeeper_port/2" do
     test "overrides the default zookeeper port used for the Kafka container" do
       config = KafkaContainer.new()
@@ -196,7 +210,7 @@ defmodule Testcontainers.Container.KafkaContainerTest do
     container(:kafka, KafkaContainer.new())
 
     test "provides a ready-to-use kafka container", %{kafka: kafka} do
-      uris = [{"localhost", Container.mapped_port(kafka, 9092) || 9092}]
+      uris = [{"localhost", Container.mapped_port(kafka, 9092)}]
 
       {:ok, pid} = KafkaEx.create_worker(:worker, uris: uris, consumer_group: "kafka_ex")
       on_exit(fn -> :ok = KafkaEx.stop_worker(pid) end)
@@ -219,8 +233,10 @@ defmodule Testcontainers.Container.KafkaContainerTest do
 
   describe "with external zookeeper" do
     test "provides a ready-to-use kafka container" do
-      {:ok, kafka} = start_kafka_with_external_zookeeper()
-      uris = [{"localhost", Container.mapped_port(kafka, 9092) || 9092}]
+      {:ok, zookeeper} = start_external_zookeeper()
+      {:ok, kafka} = start_kafka_with_external_zookeeper(zookeeper, 1, 9092)
+
+      uris = [{"localhost", Container.mapped_port(kafka, 9092)}]
 
       {:ok, pid} = KafkaEx.create_worker(:worker, uris: uris, consumer_group: "kafka_ex")
       on_exit(fn -> :ok = KafkaEx.stop_worker(pid) end)
@@ -235,6 +251,35 @@ defmodule Testcontainers.Container.KafkaContainerTest do
       _ = KafkaEx.create_topics([request], worker_name: :worker)
       {:ok, _} = KafkaEx.produce("test_topic", 0, "hey", worker_name: :worker, required_acks: 1)
       stream = KafkaEx.stream("test_topic", 0, worker_name: :worker)
+      [response] = Enum.take(stream, 1)
+
+      assert response.value == "hey"
+    end
+
+    test "with multiple connected nodes" do
+      {:ok, zookeeper} = start_external_zookeeper()
+      {:ok, kafka1} = start_kafka_with_external_zookeeper(zookeeper, 1, 9092)
+      {:ok, kafka2} = start_kafka_with_external_zookeeper(zookeeper, 2, 9093)
+
+      uris_one = [{"localhost", Container.mapped_port(kafka1, 9092)}]
+      uris_two = [{"localhost", Container.mapped_port(kafka2, 9093)}]
+
+      {:ok, pid} = KafkaEx.create_worker(:writer, uris: uris_one, consumer_group: "kafka_ex")
+      on_exit(fn -> :ok = KafkaEx.stop_worker(pid) end)
+
+      request = %KafkaEx.Protocol.CreateTopics.TopicRequest{
+        topic: "test_topic",
+        num_partitions: 1,
+        replication_factor: 1,
+        replica_assignment: []
+      }
+
+      _ = KafkaEx.create_topics([request], worker_name: :writer)
+      {:ok, _} = KafkaEx.produce("test_topic", 0, "hey", worker_name: :writer, required_acks: 1)
+
+      {:ok, pid} = KafkaEx.create_worker(:reader, uris: uris_two, consumer_group: "kafka_ex")
+      on_exit(fn -> :ok = KafkaEx.stop_worker(pid) end)
+      stream = KafkaEx.stream("test_topic", 0, worker_name: :reader)
       [response] = Enum.take(stream, 1)
 
       assert response.value == "hey"
@@ -245,7 +290,7 @@ defmodule Testcontainers.Container.KafkaContainerTest do
     container(:kafka, KafkaContainer.new() |> KafkaContainer.with_consensus_strategy(:kraft))
 
     test "provides a ready-to-use kafka container", %{kafka: kafka} do
-      uris = [{"localhost", Container.mapped_port(kafka, 9092) || 9092}]
+      uris = [{"localhost", Container.mapped_port(kafka, 9092)}]
 
       {:ok, pid} = KafkaEx.create_worker(:worker, uris: uris, consumer_group: "kafka_ex")
       on_exit(fn -> :ok = KafkaEx.stop_worker(pid) end)
@@ -266,13 +311,21 @@ defmodule Testcontainers.Container.KafkaContainerTest do
     end
   end
 
-  defp start_kafka_with_external_zookeeper do
+  defp start_external_zookeeper do
     {:ok, zookeeper} = Testcontainers.start_container(%ZookeeperContainer{})
     on_exit(fn -> Testcontainers.stop_container(zookeeper.container_id) end)
+    {:ok, zookeeper}
+  end
+
+  defp start_kafka_with_external_zookeeper(zookeeper, broker_id, port) do
+    broker_port = String.to_integer("2#{port}")
 
     {:ok, kafka} =
       Testcontainers.start_container(
         KafkaContainer.new()
+        |> KafkaContainer.with_kafka_port(port)
+        |> KafkaContainer.with_broker_port(broker_port)
+        |> KafkaContainer.with_broker_id(broker_id)
         |> KafkaContainer.with_consensus_strategy(:zookeeper_external)
         |> KafkaContainer.with_zookeeper_host(zookeeper.ip_address)
       )


### PR DESCRIPTION
## Overview
The most common production usage of Kafka is with multiple nodes. 
It is usually not required in tests to setup it with so many containers yet there are cases where we would like to have it. 

This PR is adding support for multiple brokers setup.
## Changes

- [x] External Zookeeper Support. Still Zookeeper is a generic container here. Maybe one day I'll read it docs to make it dynamic one. 
- [ ] kRaft Support
