### PR TITLE
fix: allow to run on otp 24

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -31,6 +31,8 @@ jobs:
             otp: 25.3
           - elixir: 1.13
             otp: 25.3
+          - elixir: 1.13
+            otp: 24.2
 
     steps:
     - uses: actions/checkout@v3

--- a/lib/connection/dockerurl.ex
+++ b/lib/connection/dockerurl.ex
@@ -8,7 +8,7 @@ defmodule Testcontainers.DockerUrl do
   def construct(docker_host) do
     case URI.parse(docker_host) do
       %URI{scheme: "unix", path: path} ->
-        "http+unix://#{:uri_string.quote(path)}/#{@api_version}"
+        "http+unix://#{URI.encode_www_form(path)}/#{@api_version}"
 
       %URI{scheme: "tcp"} = uri ->
         URI.to_string(%{uri | scheme: "http", path: "/#{@api_version}"})


### PR DESCRIPTION
the function: 

```
:uri_string.quote
```

was added on erlang otp25, I think the URI.encode_www_form behaves the same but is build in elixir (i checked till version 1.3.1 of elixir and it was there :P )

https://github.com/testcontainers/testcontainers-elixir/issues/88