### PR TITLE
fix: log warning when using network_mode=host on macos/windows

### DIFF
--- a/test/generic_container_test.exs
+++ b/test/generic_container_test.exs
@@ -1,6 +1,7 @@
 defmodule Testcontainers.GenericContainerTest do
   use ExUnit.Case, async: true
 
+  import Testcontainers.Container, only: [is_os: 1]
   import TestHelper, only: [port_open?: 2]
 
   test "can start and stop generic container" do
@@ -10,13 +11,14 @@ defmodule Testcontainers.GenericContainerTest do
   end
 
   test "can start and stop generic container with network mode set to host" do
-    config = %Testcontainers.Container{image: "redis:latest", network_mode: "host"}
-    assert {:ok, container} = Testcontainers.start_container(config)
-    Process.sleep(5000)
-    with {:unix, :darwin} <- :os.type() do
-      IO.puts("Testing network_mode=host doesn't work in macos!")
+    if not is_os(:linux) do
+      Testcontainers.Logger.log("Host is not Linux, therefore not running network_mode test")
+    else
+      config = %Testcontainers.Container{image: "redis:latest", network_mode: "host"}
+      assert {:ok, container} = Testcontainers.start_container(config)
+      Process.sleep(5000)
+      assert :ok = port_open?("127.0.0.1", 6379)
+      assert :ok = Testcontainers.stop_container(container.container_id)
     end
-    assert :ok = port_open?("127.0.0.1", 6379)
-    assert :ok = Testcontainers.stop_container(container.container_id)
   end
 end


### PR DESCRIPTION
fixes #111

just a suggestion for now. Might not amount to a merge. But i dont like this feature bleeding into windows or macos hosts when its not usable or tested without using direct host ip address.