### PR TITLE
add Mix task for running any command with database containers

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -24,6 +24,10 @@ jobs:
       fail-fast: false
       matrix:
         pair:
+          - elixir: 1.18
+            otp: 27.2
+          - elixir: 1.17
+            otp: 27.2
           - elixir: 1.16
             otp: 26.2
           - elixir: 1.15
@@ -32,14 +36,14 @@ jobs:
             otp: 25.3
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
         elixir-version: ${{ matrix.pair.elixir }} # [Required] Define the Elixir version
         otp-version: ${{ matrix.pair.otp }}      # [Required] Define the Erlang/OTP version
     - name: Restore dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: deps
         key: ${{ runner.os }}-${{ matrix.pair.otp }}-${{ matrix.pair.elixir }}-mix-${{ hashFiles('**/mix.lock') }}
@@ -58,12 +62,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.16' # [Required] Define the Elixir version
-        otp-version: '26.2'      # [Required] Define the Erlang/OTP version
+        elixir-version: '1.18' # [Required] Define the Elixir version
+        otp-version: '27.2'      # [Required] Define the Erlang/OTP version
     - name: Run example phoenix project tests
       run: |
        cd examples/phoenix_project

--- a/README.md
+++ b/README.md
@@ -98,13 +98,41 @@ container(:redis, Testcontainers.RedisContainer.new())
 
 ### Run tests in a Phoenix project (or any project for that matter)
 
-To run/wrap testcontainers around a project use the testcontainers.test task.
+To run/wrap testcontainers around a project use the testcontainers.run task.
 
-`mix testcontainers.test [--database postgres|mysql] [--watch dir ...]`
+`mix testcontainers.run [sub_task] [--database postgres|mysql] [--watch dir ...] [--db-volume VOLUME]`
 
 to use postgres you can just run
 
-`mix testcontainers.test` since postgres is default.
+`mix testcontainers.run test` since postgres is default and test is the default sub-task.
+
+#### Examples:
+
+```bash
+# Run tests with PostgreSQL (default)
+mix testcontainers.run test
+
+# Run tests with MySQL
+mix testcontainers.run test --database mysql
+
+# Run Phoenix server with PostgreSQL and persistent volume
+mix testcontainers.run phx.server --database postgres --db-volume my_postgres_data
+
+# Run tests with MySQL and persistent volume
+mix testcontainers.run test --database mysql --db-volume my_mysql_data
+
+# Run tests with file watching
+mix testcontainers.run test --watch lib --watch test
+```
+
+#### Persistent Volumes
+
+The `--db-volume` parameter allows you to specify a persistent volume for database data. This ensures that your database data persists between container restarts. The volume name you provide will be used to create a Docker volume that gets mounted to the appropriate database data directory:
+
+- **PostgreSQL**: Volume is mounted to `/var/lib/postgresql/data`
+- **MySQL**: Volume is mounted to `/var/lib/mysql`
+
+This is particularly useful when you want to maintain database state across test runs or development sessions.
 
 in your config/test.exs you can then change the repo config to this:
 
@@ -121,11 +149,11 @@ config :my_app, MyApp.Repo,
 
 Activate reuse of database containers started by mix task with adding `testcontainers.reuse.enable=true` in `~/.testcontainers.properties`. This is experimental.
 
-You can pass arguments to mix test by append -- to the of the command like this:
+You can pass arguments to the sub-task by appending them after the sub-task name. For example, to pass arguments to mix test:
 
-`mix testcontainers.test -- --exclude flaky --stale`
+`mix testcontainers.run test --exclude flaky --stale`
 
-In the example above we are excluding flaky tests and using the --stale option.
+In the example above we are running tests while excluding flaky tests and using the --stale option.
 
 ### Logging
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,22 @@ You can pass arguments to the sub-task by appending them after the sub-task name
 
 In the example above we are running tests while excluding flaky tests and using the --stale option.
 
+#### Backward Compatibility
+
+For backward compatibility, the old `mix testcontainers.test` task is still available and works exactly as before. It automatically delegates to `mix testcontainers.run test`, so existing scripts and workflows will continue to work without modification:
+
+```bash
+# These commands are equivalent:
+mix testcontainers.test --database mysql
+mix testcontainers.run test --database mysql
+
+# Both support all the same options:
+mix testcontainers.test --database postgres --db-volume my_data
+mix testcontainers.run test --database postgres --db-volume my_data
+```
+
+While the old task will continue to work, we recommend updating to `mix testcontainers.run` for new projects as it provides more flexibility by allowing you to run any Mix task, not just tests.
+
 ### Logging
 
 Testcontainers use the standard Logger, see https://hexdocs.pm/logger/Logger.html.

--- a/lib/mix/tasks/testcontainers/run.ex
+++ b/lib/mix/tasks/testcontainers/run.ex
@@ -1,9 +1,19 @@
-defmodule Mix.Tasks.Testcontainers.Test do
+defmodule Mix.Tasks.Testcontainers.Run do
   use Mix.Task
   alias Testcontainers.PostgresContainer
   alias Testcontainers.MySqlContainer
 
-  @shortdoc "Runs tests with a Postgres container"
+  @shortdoc "Runs a Mix sub-task (test, phx.server, etc) with a database container"
+  @moduledoc """
+  Usage:
+    mix testcontainers.run [sub_task] [--database DB] [--watch folder] [sub_task_args...]
+
+  Examples:
+    mix testcontainers.run test --database postgres
+    mix testcontainers.run phx.server --database mysql
+    mix testcontainers.run test --watch lib --watch test
+  """
+
   def run(args) do
     Enum.each([:tesla, :hackney, :fs, :logger], fn app ->
       {:ok, _} = Application.ensure_all_started(app)
@@ -11,7 +21,7 @@ defmodule Mix.Tasks.Testcontainers.Test do
 
     {:ok, _} = Testcontainers.start_link()
 
-    {opts, args, _} =
+    {opts, rest_args, _} =
       OptionParser.parse(args,
         switches: [
           database: :string,
@@ -22,12 +32,19 @@ defmodule Mix.Tasks.Testcontainers.Test do
     database = opts[:database] || "postgres"
     folder_to_watch = Keyword.get_values(opts, :watch)
 
+    # Determine sub_task and its args
+    {sub_task, sub_task_args} =
+      case rest_args do
+        [task | tail] -> {task, tail}
+        [] -> {"test", []}
+      end
+
     if Enum.empty?(folder_to_watch) do
-      IO.puts("No folders specified. Only running tests.")
-      run_tests_and_exit(database, args)
+      IO.puts("No folders specified. Only running sub-task '#{sub_task}'.")
+      run_sub_task_and_exit(database, sub_task, sub_task_args)
     else
       check_folders_exist(folder_to_watch)
-      run_tests_and_watch(database, args, folder_to_watch)
+      run_sub_task_and_watch(database, sub_task, sub_task_args, folder_to_watch)
     end
   end
 
@@ -39,15 +56,15 @@ defmodule Mix.Tasks.Testcontainers.Test do
     end)
   end
 
-  @spec run_tests_and_exit(String.t(), list(String.t())) :: no_return()
-  defp run_tests_and_exit(database, args) do
+  @spec run_sub_task_and_exit(String.t(), String.t(), list(String.t())) :: no_return()
+  defp run_sub_task_and_exit(database, sub_task, sub_task_args) do
     {container, env} = setup_container(database)
-    exit_code = run_tests(env, args)
+    exit_code = run_mix_task(env, sub_task, sub_task_args)
     Testcontainers.stop_container(container.container_id)
     System.halt(exit_code)
   end
 
-  defp run_tests_and_watch(database, args, folders) do
+  defp run_sub_task_and_watch(database, sub_task, sub_task_args, folders) do
     {container, env} = setup_container(database)
 
     Enum.each(folders, fn folder ->
@@ -55,8 +72,8 @@ defmodule Mix.Tasks.Testcontainers.Test do
       :fs.subscribe(String.to_atom("watcher_" <> folder))
     end)
 
-    run_tests(env, args)
-    loop(env, args, container)
+    run_mix_task(env, sub_task, sub_task_args)
+    loop(env, sub_task, sub_task_args, container)
   end
 
   defp setup_container(database) do
@@ -99,44 +116,43 @@ defmodule Mix.Tasks.Testcontainers.Test do
     ]
   end
 
-  defp run_tests(env, args) do
-    case System.cmd("mix", ["test"] ++ args,
+  defp run_mix_task(env, sub_task, sub_task_args) do
+    case System.cmd("mix", [sub_task] ++ sub_task_args,
            env: env,
            into: IO.stream(),
            stderr_to_stdout: false
          ) do
       {_, exit_code} ->
         if exit_code == 0 do
-          IO.puts("Test process completed successfully")
+          IO.puts("Mix task '#{sub_task}' completed successfully")
         else
-          IO.puts(:stderr, "Test process failed with exit code: #{exit_code}")
+          IO.puts(:stderr, "Mix task '#{sub_task}' failed with exit code: #{exit_code}")
         end
-
         exit_code
     end
   end
 
-  defp loop(env, args, container) do
+  defp loop(env, sub_task, sub_task_args, container) do
     receive do
       {_watcher_process, {:fs, :file_event}, {changed_file, _type}} ->
         IO.puts("#{changed_file} was updated, waiting for more changes...")
-        wait_for_changes(env, args, container)
+        wait_for_changes(env, sub_task, sub_task_args, container)
     after
       5000 ->
-        loop(env, args, container)
+        loop(env, sub_task, sub_task_args, container)
     end
   end
 
-  defp wait_for_changes(env, args, container) do
+  defp wait_for_changes(env, sub_task, sub_task_args, container) do
     receive do
       {_watcher_process, {:fs, :file_event}, {changed_file, _type}} ->
         IO.puts("#{changed_file} was updated, waiting for more changes...")
-        wait_for_changes(env, args, container)
+        wait_for_changes(env, sub_task, sub_task_args, container)
     after
       1000 ->
         IO.ANSI.clear()
-        run_tests(env, args)
-        loop(env, args, container)
+        run_mix_task(env, sub_task, sub_task_args)
+        loop(env, sub_task, sub_task_args, container)
     end
   end
 end

--- a/lib/mix/tasks/testcontainers/run.ex
+++ b/lib/mix/tasks/testcontainers/run.ex
@@ -124,7 +124,7 @@ defmodule Mix.Tasks.Testcontainers.Run do
          ) do
       {_, exit_code} ->
         if exit_code == 0 do
-          IO.puts("Mix task '#{sub_task}' completed successfully")
+          IO.puts("Task '#{sub_task}' completed successfully")
         else
           IO.puts(:stderr, "Mix task '#{sub_task}' failed with exit code: #{exit_code}")
         end

--- a/lib/mix/tasks/testcontainers/run.ex
+++ b/lib/mix/tasks/testcontainers/run.ex
@@ -40,7 +40,7 @@ defmodule Mix.Tasks.Testcontainers.Run do
       end
 
     if Enum.empty?(folder_to_watch) do
-      IO.puts("No folders specified. Only running sub-task '#{sub_task}'.")
+      IO.puts("No folders specified. Only running subtask '#{sub_task}'.")
       run_sub_task_and_exit(database, sub_task, sub_task_args)
     else
       check_folders_exist(folder_to_watch)

--- a/lib/mix/tasks/testcontainers/test.ex
+++ b/lib/mix/tasks/testcontainers/test.ex
@@ -1,0 +1,9 @@
+defmodule Mix.Tasks.Testcontainers.Test do
+  use Mix.Task
+
+  @shortdoc "Runs mix test with Testcontainers (backward compatibility)"
+
+  def run(args) do
+    Mix.Task.run("testcontainers.run", ["test" | args])
+  end
+end

--- a/lib/util/constants.ex
+++ b/lib/util/constants.ex
@@ -2,7 +2,7 @@ defmodule Testcontainers.Constants do
   @moduledoc false
 
   def library_name, do: :testcontainers
-  def library_version, do: "1.12.0"
+  def library_version, do: "1.13.0"
   def ryuk_version, do: "0.11.0"
   def container_label, do: "org.testcontainers"
   def container_lang_label, do: "org.testcontainers.lang"

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule TestcontainersElixir.MixProject do
   use Mix.Project
 
   @app :testcontainers
-  @version "1.12.0"
+  @version "1.13.0"
   @source_url "https://github.com/testcontainers/testcontainers-elixir"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -84,7 +84,8 @@ defmodule TestcontainersElixir.MixProject do
   defp aliases do
     [
       setup: ["deps.get"],
-      citest: ["test --exclude flaky --cover"]
+      citest: ["test --exclude flaky --cover"],
+      "testcontainers.test": ["testcontainers.run test"]
     ]
   end
 end


### PR DESCRIPTION
add alias for old name
keep old mix task name by making a thin wrapper for run
fixes #187

- [x] Add volume mount, maybe configurable via optional parameter, for persistent db state